### PR TITLE
fix: 주간 리뷰 알림 요일 수정 (KST 일요일 → 토요일)

### DIFF
--- a/bot/cogs/scheduler.py
+++ b/bot/cogs/scheduler.py
@@ -23,11 +23,11 @@ class Scheduler(commands.Cog):
         self.weekly_reminder.cancel()
         self.submission_reminder.cancel()
 
-    @tasks.loop(time=time(hour=22, minute=30))  # UTC 22:30 = KST 07:30
+    @tasks.loop(time=time(hour=22, minute=30))  # UTC 금요일 22:30 = KST 토요일 07:30
     async def weekly_reminder(self):
-        """주말 리뷰 세션 30분 전 알림 (토요일)"""
+        """주말 리뷰 세션 30분 전 알림 (KST 토요일)"""
         now = datetime.now()
-        if now.weekday() != 5:
+        if now.weekday() != 4:  # UTC 금요일 = KST 토요일
             return
 
         channel = self.bot.get_channel(self.announcement_channel_id)


### PR DESCRIPTION
## Summary
- UTC 기준 weekday 체크로 인해 KST 일요일에 알림이 발송되던 문제 수정
- `weekday != 5` → `weekday != 4`로 변경하여 KST 토요일 07:30에 정상 발송